### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_shake_plugin
 description: A new Flutter plugin.
-version: 0.0.1
+version: 0.0.2
 author: Damon<3262663349@qq.com>
 homepage: https://github.com/ChallengeHe/FlutterShakePlugin
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   vibration: ^1.0.2
-  sensors: ^0.4.0+1
+  sensors: '>=0.4.0+1 <2.0.0'
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).